### PR TITLE
Signal availability, and fix typography site-wide

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,8 +1,17 @@
 const cleanCSS = require('clean-css');
+const markdownIt = require('markdown-it');
 const syntaxHighlight = require('@11ty/eleventy-plugin-syntaxhighlight');
 const eleventyNavigation = require('@11ty/eleventy-navigation');
 
 module.exports = function(eleventyConfig) {
+  /* Typographer turns straight quotes into curly ones, and -- into a dash, so
+     prose doesn't depend on remembering to type entities. It only touches text
+     tokens: code blocks, inline code and raw HTML attributes are left alone. */
+  eleventyConfig.setLibrary(
+    'md',
+    markdownIt({ html: true, breaks: false, linkify: false, typographer: true })
+  );
+
   // Clean and minimize CSS
   eleventyConfig.addFilter('cssmin', function(code) {
     return new cleanCSS({}).minify(code).styles;

--- a/src/about.md
+++ b/src/about.md
@@ -9,7 +9,7 @@ The blend of visual design, user interaction, and code had me hooked. My guestbo
 
 Studying graphic design in college gave me an understanding of typography, color, motion, layout, empathy, and intent&mdash;skills that I bring into my code.
 
-Offline - I live in Tacoma, WA with my spouse, where we enjoy exploring the city and trying new restaurants and food trucks. I also spend time with watercolors, sewing machines, freshwater aquariums, and parks with lots of shade.
+Offline — I live in Tacoma, WA with my spouse, where we enjoy exploring the city and trying new restaurants and food trucks. I also spend time with watercolors, sewing machines, freshwater aquariums, and parks with lots of shade.
 
 ## Writing
 

--- a/src/includes/partials/header.njk
+++ b/src/includes/partials/header.njk
@@ -12,10 +12,10 @@
 
             <h1 class="header__title">Monika Hoex <em>is a collaborative web designer &amp; developer.</em></h1>
 
-            <p class="header__description header__intro">I have over twenty years of experience building effective web-based solutions and systems for a diverse set of clients.</p>
-            <p class="header__description">I bridge the space between design and development, while advocating for the user by focusing on accessible, responsive, maintainable design systems.</p>
+            <p class="header__description header__intro">I have over twenty years of experience building effective web-based solutions for a diverse set of clients.</p>
+            <p class="header__description">Design and development aren&rsquo;t separate practices for me - both are ways of communicating with the user, ultimately expressed through accessible, responsive, maintainable systems.</p>
 
-            <a class="header__action button" href="mailto:monika@monika.dev">Email Me</a>
+            <p class="header__availability">I&rsquo;m currently available for full-time roles: <a href="mailto:monika@monika.dev">monika@monika.dev</a>.</p>
 
         {% endif %}
 

--- a/src/projects/salesforce/salesforce.md
+++ b/src/projects/salesforce/salesforce.md
@@ -16,7 +16,7 @@ _A fresh, exciting, and friendly new eBook from Salesforce that provides industr
 
 Folks are hungry for business insight and Salesforce provides that insight in many forms, one of which is their eBooks. Salesforce needed to bring their latest eBook, beautifully designed by the team at IRON Creative, into the browser.
 
-I pushed the edges of technology and centered the animations on our eBook in a new video format, which is set to gracefully downgrade for older browsers. Fun illustrations and iconography are presented as scalable and small vector files, keeping the loading speed quick, the rendering time fast, and the site responsive for various browser sizes and devices - getting people to the insight they want to see as efficiently as possible.
+I pushed the edges of technology and centered the animations on our eBook in a new video format, which is set to gracefully downgrade for older browsers. Fun illustrations and iconography are presented as scalable and small vector files, keeping the loading speed quick, the rendering time fast, and the site responsive for various browser sizes and devices — getting people to the insight they want to see as efficiently as possible.
 
 [Visit Salesforce eBook &#10132; (Dev URL)](https://gallant-liskov-7a6a1b.netlify.com/)
 

--- a/src/scss/_module-header.scss
+++ b/src/scss/_module-header.scss
@@ -27,7 +27,12 @@
     font-weight: 400;
     font-size: 2.4rem;
   }
-  &__action {
-    margin-top: 2rem;
+  /* Only the address is a link, so the sentence stays body-coloured — blue
+     text here read as a link that wasn't one. */
+  &__availability {
+    max-width: 65ch;
+    margin: 2rem 0 0;
+
+    font-weight: 700;
   }
 }

--- a/src/scss/_typography.scss
+++ b/src/scss/_typography.scss
@@ -128,6 +128,19 @@ h6 {
   font-style: normal;
   line-height: 1.25;
   text-transform: capitalize;
+
+  /* Even out the line lengths rather than filling each line before wrapping,
+     so a heading doesn't end on a single stranded word. */
+  text-wrap: balance;
+}
+
+/* Same idea for running text, but tuned for longer copy: the browser avoids
+   leaving an orphan on the last line without rebalancing the whole block.
+   Both degrade to normal wrapping where unsupported. */
+p,
+li,
+figcaption {
+  text-wrap: pretty;
 }
 
 h1 {


### PR DESCRIPTION
Add an availability line to the homepage lockup, worded for full-time roles so it doesn't read as an invitation to freelance enquiries, with the address itself as the link — the previous styling coloured the whole sentence blue, which looked like a link that wasn't one.

Turn on markdown-it's typographer so prose gets real quotes and apostrophes without anyone remembering to type entities. It only rewrites text tokens, so the code samples on the project pages are untouched. Templates aren't markdown, so those are fixed by hand.

Add text-wrap: balance to headings and text-wrap: pretty to running text, so headings stop stranding a single word and paragraphs stop ending on an orphan. Both fall back to normal wrapping.

Also tighten the homepage copy: the two description paragraphs both opened with "I", which read as a list of assertions rather than prose.