### PR TITLE
Only load analytics on production builds

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -12,6 +12,14 @@ module.exports = function(eleventyConfig) {
     markdownIt({ html: true, breaks: false, linkify: false, typographer: true })
   );
 
+  /* Netlify sets CONTEXT on its builds, so this is true only for a production
+     deploy — local previews, branch deploys and deploy previews all skip the
+     analytics tag rather than reporting themselves as real traffic. */
+  eleventyConfig.addGlobalData(
+    'isProduction',
+    process.env.CONTEXT === 'production'
+  );
+
   // Clean and minimize CSS
   eleventyConfig.addFilter('cssmin', function(code) {
     return new cleanCSS({}).minify(code).styles;

--- a/src/includes/partials/footer.njk
+++ b/src/includes/partials/footer.njk
@@ -21,6 +21,7 @@
 </div>
 </footer>
 
+{% if isProduction %}
 <!-- Global site tag (gtag.js) - Google Analytics -->
 <script async src="https://www.googletagmanager.com/gtag/js?id={{ meta.gaId }}"></script>
 <script>
@@ -30,3 +31,4 @@ gtag('js', new Date());
 
 gtag('config', '{{ meta.gaId }}');
 </script>
+{% endif %}

--- a/src/includes/partials/head.njk
+++ b/src/includes/partials/head.njk
@@ -15,7 +15,7 @@
 {% include "partials/meta.njk" %}
 {% include "partials/structured-data.njk" %}
 
-<link rel="dns-prefetch" href="https://www.googletagmanager.com">
+{% if isProduction %}<link rel="dns-prefetch" href="https://www.googletagmanager.com">{% endif %}
 <link rel="preconnect" href="https://use.typekit.net">
 <link rel="dns-prefetch" href="https://use.typekit.net">
 


### PR DESCRIPTION
The Google tag fired everywhere, including the local dev server, so previewing unpublished drafts reported them to GA as real pageviews. Automated runs made it worse: a Lighthouse audit loads the page several times and each one counted, which is where last month's homepage traffic came from.

Gate the tag and its DNS hint on Netlify's CONTEXT, so it only ships on a production deploy. Branch deploys and deploy previews stay out of the data too, and unpublished URLs are never sent to Google at all rather than being filtered out after the fact.

Also stops a 152KB third-party request loading during local performance testing, which was inflating those measurements.